### PR TITLE
Generalization to IoFormBundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,20 @@ How to Install
   target=/bundles/Io/FormBundle
 ```
 
-      Run the vendor script:
+ Run the vendor script:
 
 ```
-        ./bin/vendors install
+./bin/vendors install
 ```
 
-    * Submodule Mode
+ * Submodule Mode
 
 ```
-       $ git submodule add git://github.com/ioalessio/IoFormBundle.git vendor/bundles/Io/FormBundle
+$ git submodule add git://github.com/ioalessio/IoFormBundle.git vendor/bundles/Io/FormBundle
 ```
 
 
-  2. Add the "Io" namespace to your autoloader:
+ 2. Add the "Io" namespace to your autoloader:
 
 ```php
 <?php

--- a/README.md
+++ b/README.md
@@ -6,30 +6,40 @@ How to Install
     * Vendor Mode
       Add the following lines in your deps file::
 
-        [IoFormBundle]
-        git=git://github.com/ioalessio/IoFormBundle.git
-        target=/bundles/Io/FormBundle
-
+```
+[IoFormBundle]
+  git=git://github.com/ioalessio/IoFormBundle.git
+  target=/bundles/Io/FormBundle
+```
 
       Run the vendor script:
 
+```
         ./bin/vendors install
+```
 
     * Submodule Mode
-       $ git submodule add git://github.com/ioalessio/IoFormBundle.git vendor/bundles/Io/FormBundle
 
+```
+       $ git submodule add git://github.com/ioalessio/IoFormBundle.git vendor/bundles/Io/FormBundle
+```
 
 
   2. Add the "Io" namespace to your autoloader:
 
-        // app/autoload.php
-        $loader->registerNamespaces(array(
-        'Io' => __DIR__.'/../vendor/bundles',
-        // your other namespaces
-        ));
+```php
+<?php
+// app/autoload.php
+$loader->registerNamespaces(array(
+    'Io' => __DIR__.'/../vendor/bundles',
+// your other namespaces
+));
+```
 
   3. Add the "Io" namespace to your autoloader:
 
+```php
+<?php
         // app/ApplicationKernel.php
         public function registerBundles()
         {
@@ -39,9 +49,11 @@ How to Install
                 // ...
             );
         }
+```
 
   4. Add the twig form configuration:
 
+```jinja
         // app/config/config.yml
         twig:
             form:
@@ -52,13 +64,15 @@ How to Install
             jquery_tinymce:
               source: /bundles/yourbundle/js/tiny_mce/tiny_mce.js
               theme:  simple
-
+```
 
 How to use Form Type
 ====================
   Build your form:
 
-    ...
+
+```php
+<?php
     public function buildForm(FormBuilder $builder, array $options)
     {
         $builder
@@ -68,13 +82,43 @@ How to use Form Type
             ->add('note', 'jquery_tinymce')
         );
     }
+```
 
  Several options are available on jquery_date widget
+
+ ```php
+ <?php
+ $builder->add('the_date', 'jquery_date', array(
   'format' => 'dd/MM/y'  'dd.MM.yy' 'd MMM, y'
   'changeMonth'=> 'true',
   'changeYear' => true,
   'minDate'=> '-1y',
-  'maxDate'=> '+1y'
+  'maxDate'=> '+1y',
+  'yearRange' => '-1y:+1y',
+  'showOn' => 'focus'
+));
+```
+
+In addition, non-supported datepicker options can be added by prepending with "jqd."
+
+```php
+<?php
+ $builder->add('the_date', 'jquery_date', array(
+ ...
+  'jqd.appendText' => 'extra text',
+  'jqd.buttonText' => 'BUTTON!'
+))
+```
+
+Will render as:
+
+```javascript
+$( "#wn_trackingbundle_resulttype_date" ).datepicker({
+    ...
+    appendText: 'boosh!',
+    buttonText: 'BUTTON!'
+});
+```
 
 More details on some types:
 

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -127,12 +127,16 @@
           <script>
           $(function() {
             $( "#{{ id }}" ).datepicker({
-                dateFormat: '{{ date_format }}',
-                changeMonth: {{ change_month }},
-                changeYear:  {{ change_year }},
-                minDate:  '{{ min_date }}',
-                maxDate:  '{{ max_date }}',
-                showOn: "button"
+                dateFormat: '{{ dateFormat }}',
+              {% for key,value in jqdate_options %}
+                {{key}}: '{{value}}',
+              {% endfor %}
+                {#changeMonth: {{ change_month }},#}
+                {#changeYear: {{ change_year }},#}
+                {#minDate: '{{ min_date }}',#}
+                {#maxDate: '{{ max_date }}',#}
+                {#yearRange: '{{ year_range }}',#}
+                {#showOn: '{{ show_on }}'#}
               });
              $( "#{{ id }}" ).datepicker( $.datepicker.regional[ "{{locale}}" ] );
           });


### PR DESCRIPTION
If interested, I have removed direct references to jqdate options in most locations.. Instead, there is a 'valid options' array and a 'default options' array that allow you to define specific supported options.

Prefixing a non-supported option with "jqd." will allow its use without changing the bundle.
